### PR TITLE
Performance optimisations

### DIFF
--- a/src/integrations/sproutforms/captchas/GoogleRecaptcha.php
+++ b/src/integrations/sproutforms/captchas/GoogleRecaptcha.php
@@ -146,7 +146,7 @@ class GoogleRecaptcha extends Captcha
     {
         $googleRecaptchaFile = $this->getScript();
 
-        Craft::$app->view->registerJsFile($googleRecaptchaFile, ['defer' => 'defer']);
+        Craft::$app->view->registerJsFile($googleRecaptchaFile, ['defer' => 'defer', 'async' => 'async']);
 
         Craft::$app->view->registerJs("window.onload = function() {
             var recaptcha = document.querySelector('#g-recaptcha-response');

--- a/src/integrations/sproutforms/captchas/GoogleRecaptcha.php
+++ b/src/integrations/sproutforms/captchas/GoogleRecaptcha.php
@@ -146,7 +146,7 @@ class GoogleRecaptcha extends Captcha
     {
         $googleRecaptchaFile = $this->getScript();
 
-        Craft::$app->view->registerJsFile($googleRecaptchaFile);
+        Craft::$app->view->registerJsFile($googleRecaptchaFile, ['defer' => 'defer']);
 
         Craft::$app->view->registerJs("window.onload = function() {
             var recaptcha = document.querySelector('#g-recaptcha-response');

--- a/src/integrations/sproutforms/captchas/GoogleRecaptcha.php
+++ b/src/integrations/sproutforms/captchas/GoogleRecaptcha.php
@@ -13,6 +13,7 @@ namespace barrelstrength\sproutformsgooglerecaptcha\integrations\sproutforms\cap
 use barrelstrength\sproutforms\base\Captcha;
 use barrelstrength\sproutforms\events\OnBeforeSaveEntryEvent;
 use Craft;
+use craft\web\View;
 
 /**
  * Google reCAPTCHA v2 class
@@ -153,7 +154,7 @@ class GoogleRecaptcha extends Captcha
             if(recaptcha) {
                 recaptcha.setAttribute('required', '');
             }
-        };");
+        };", View::POS_END);
 
         Craft::$app->view->registerCss('#g-recaptcha-response {
             display: block !important;


### PR DESCRIPTION
There are two things of note in this PR:

1. Add `async` and `defer` to the `api.js` file, as [Google recommends](https://developers.google.com/recaptcha/docs/display). This would produce:
```
<script src="https://www.google.com/recaptcha/api.js?" defer="defer" async="async"></script>
```

2. Explicitly render the required JS at the end of the document. In our testing, leaving as-is, jQuery would be loaded onto the page just for this plugin. As some of our projects are sans-jQuery, we certainly don't want this to happen. See screenshot for the output (no other plugins installed, no devMode, production server).

![screen shot 2018-11-22 at 10 04 42 am](https://user-images.githubusercontent.com/1221575/48872796-cbd64380-ee3e-11e8-9402-2136c4b5cebf.png)

This is a quick fix that works, but you could also do a front-end Asset Bundle as another option.