### PR TITLE
Return Type hints have broken plugin

### DIFF
--- a/src/integrations/sproutforms/captchas/GoogleRecaptcha.php
+++ b/src/integrations/sproutforms/captchas/GoogleRecaptcha.php
@@ -115,12 +115,12 @@ class GoogleRecaptcha extends Captcha
         $this->remoteIp = $_SERVER['REMOTE_ADDR'];
     }
 
-    public function getName()
+    public function getName(): string
     {
         return 'Google Recaptcha';
     }
 
-    public function getDescription()
+    public function getDescription(): string
     {
         return Craft::t('sprout-forms-google-recaptcha', 'Adds Google reCAPTCHA to Sprout Forms');
     }
@@ -132,7 +132,7 @@ class GoogleRecaptcha extends Captcha
      * @throws \Twig_Error_Loader
      * @throws \yii\base\Exception
      */
-    public function getCaptchaSettingsHtml()
+    public function getCaptchaSettingsHtml(): string
     {
         $settings = $this->getSettings();
 
@@ -143,7 +143,7 @@ class GoogleRecaptcha extends Captcha
         return $html;
     }
 
-    public function getCaptchaHtml()
+    public function getCaptchaHtml(): string
     {
         $googleRecaptchaFile = $this->getScript();
 


### PR DESCRIPTION
Due to the function type hints in https://github.com/barrelstrength/craft-sprout-forms/commit/c047f7064172f0617cfba878becb028215b93b6e#diff-dbbc6da4cd61604a184eeb5b9db808d7, the plugin throws an error when any form is used.

```
Declaration of barrelstrength\sproutformsgooglerecaptcha\integrations\sproutforms\captchas\GoogleRecaptcha::getName() must be compatible with barrelstrength\sproutforms\base\Captcha::getName(): string
```

This PR adds those type hints.