### PR TITLE
Remove `hasCpSettings`

### DIFF
--- a/src/SproutFormsGoogleRecaptcha.php
+++ b/src/SproutFormsGoogleRecaptcha.php
@@ -26,11 +26,6 @@ use yii\base\Event;
 class SproutFormsGoogleRecaptcha extends Plugin
 {
     /**
-     * @var bool
-     */
-    public $hasCpSettings = true;
-
-    /**
      * @inheritdoc
      */
     public function init()


### PR DESCRIPTION
There are no settings for the plugin (directly anyway) and its annoying having a blank settings screen for the plugin - thinking that's where you can set captcha information. Can this be removed (false by default)?