### PR TITLE
Type and badge

### DIFF
--- a/src/integrations/sproutforms/captchas/GoogleRecaptcha.php
+++ b/src/integrations/sproutforms/captchas/GoogleRecaptcha.php
@@ -119,6 +119,8 @@ class GoogleRecaptcha extends Captcha
      */
     protected $badge;
 
+    protected $captchaType;
+
     /**
      * Initialize site and secret keys
      *
@@ -133,9 +135,9 @@ class GoogleRecaptcha extends Captcha
 
         // Set the type and badge
         $this->badge = $settings['googleRecaptchaBadge'] ?? null;
-        $type = $settings['googleRecaptchaType'] ?? null;
+        $this->captchaType = $settings['googleRecaptchaType'] ?? null;
 
-        if ($type === static::RECAPTCHA_TYPE_V2_INVISIBLE) {
+        if ($this->captchaType === static::RECAPTCHA_TYPE_V2_INVISIBLE) {
             $this->size = 'invisible';
         }
     }
@@ -174,12 +176,20 @@ class GoogleRecaptcha extends Captcha
 
         Craft::$app->view->registerJsFile($googleRecaptchaFile, ['defer' => 'defer', 'async' => 'async']);
 
-        Craft::$app->view->registerJs("window.onload = function() {
-            var recaptcha = document.querySelector('#g-recaptcha-response');
-            if(recaptcha) {
-                recaptcha.setAttribute('required', '');
-            }
-        };", View::POS_END);
+        if ($this->captchaType === static::RECAPTCHA_TYPE_V2_CHECKBOX) {
+            Craft::$app->view->registerJs("window.onload = function() {
+                var recaptcha = document.querySelector('#g-recaptcha-response');
+                if(recaptcha) {
+                    recaptcha.setAttribute('required', '');
+                }
+            };", View::POS_END);
+        }
+
+        if ($this->captchaType === static::RECAPTCHA_TYPE_V2_INVISIBLE) {
+            Craft::$app->view->registerJs("window.onload = function() {
+                grecaptcha.execute();
+            };", View::POS_END);
+        }
 
         $html = '';
 

--- a/src/integrations/sproutforms/captchas/GoogleRecaptcha.php
+++ b/src/integrations/sproutforms/captchas/GoogleRecaptcha.php
@@ -121,6 +121,8 @@ class GoogleRecaptcha extends Captcha
 
     protected $captchaType;
 
+    protected $includeApi = true;
+
     /**
      * Initialize site and secret keys
      *
@@ -173,8 +175,10 @@ class GoogleRecaptcha extends Captcha
     public function getCaptchaHtml(): string
     {
         $googleRecaptchaFile = $this->getScript();
-
-        Craft::$app->view->registerJsFile($googleRecaptchaFile, ['defer' => 'defer', 'async' => 'async']);
+        
+        if ($this->includeApi) {
+            Craft::$app->view->registerJsFile($googleRecaptchaFile, ['defer' => 'defer', 'async' => 'async']);
+        }
 
         if ($this->captchaType === static::RECAPTCHA_TYPE_V2_CHECKBOX) {
             Craft::$app->view->registerJs("window.onload = function() {

--- a/src/integrations/sproutforms/captchas/GoogleRecaptcha.php
+++ b/src/integrations/sproutforms/captchas/GoogleRecaptcha.php
@@ -36,6 +36,9 @@ class GoogleRecaptcha extends Captcha
 
     const API_RUL = 'https://www.google.com/recaptcha/api.js';
 
+    const RECAPTCHA_TYPE_V2_CHECKBOX  = 'v2_checkbox';
+    const RECAPTCHA_TYPE_V2_INVISIBLE = 'v2_invisible';
+
     /**
      * @var string
      */
@@ -109,6 +112,14 @@ class GoogleRecaptcha extends Captcha
     protected $size;
 
     /**
+     * Captcha size. Default : bottomright
+     *
+     * @var string
+     * @see https://developers.google.com/recaptcha/docs/invisible#config
+     */
+    protected $badge;
+
+    /**
      * Initialize site and secret keys
      *
      * @throws ReflectionException
@@ -119,6 +130,14 @@ class GoogleRecaptcha extends Captcha
         $this->siteKey = $settings['googleRecaptchaSiteKey'] ?? null;
         $this->secretKey = $settings['googleRecaptchaSecretKey'] ?? null;
         $this->remoteIp = $_SERVER['REMOTE_ADDR'];
+
+        // Set the type and badge
+        $this->badge = $settings['googleRecaptchaBadge'] ?? null;
+        $type = $settings['googleRecaptchaType'] ?? null;
+
+        if ($type === static::RECAPTCHA_TYPE_V2_INVISIBLE) {
+            $this->size = 'invisible';
+        }
     }
 
     public function getName(): string
@@ -177,6 +196,10 @@ class GoogleRecaptcha extends Captcha
 
             if ($this->size !== null) {
                 $data .= ' data-size="'.$this->size.'"';
+            }
+
+            if ($this->badge !== null) {
+                $data .= ' data-badge="'.$this->badge.'"';
             }
 
             $html = '<div class="g-recaptcha" '.$data.'></div>';
@@ -280,6 +303,17 @@ class GoogleRecaptcha extends Captcha
     public function setSize($size)
     {
         $this->size = $size;
+    }
+
+    /**
+     * Set badge
+     *
+     * @param string $badge (see https://developers.google.com/recaptcha/docs/display#render_param)
+     *
+     */
+    public function setBadge($badge)
+    {
+        $this->badge = $badge;
     }
 
     /**

--- a/src/templates/_integrations/sproutforms/captchas/GoogleRecaptcha/settings.twig
+++ b/src/templates/_integrations/sproutforms/captchas/GoogleRecaptcha/settings.twig
@@ -22,3 +22,43 @@
     required: true,
     value: settings['googleRecaptchaSecretKey'] ?? null
 }) }}
+
+{% set googleRecaptchaType = settings.googleRecaptchaType ?? 'v2_checkbox' %}
+
+{{ forms.selectField({
+    label: 'Type'|t('sprout-forms-google-recaptcha'),
+    instructions: 'Select the type of captcha to show. This should mimick the value you choose when creating the captcha.'|t('sprout-forms-google-recaptcha'),
+    id: 'googleRecaptchaType',
+    name: 'captchaSettings['~captchaId~'][googleRecaptchaType]',
+    required: true,
+    toggle: true,
+    targetPrefix: 'badge-settings-',
+    value: googleRecaptchaType,
+    options: [{
+        value: 'v2_checkbox',
+        label: 'reCAPTCHA v2 - "I\'m not a robot" Checkbox',
+    }, {
+        value: 'v2_invisible',
+        label: 'reCAPTCHA v2 - Invisible reCAPTCHA badge',
+    }]
+}) }}
+
+<div id="badge-settings-v2_invisible"{% if googleRecaptchaType != 'v2_invisible' %} class="hidden"{% endif %}>
+    {{ forms.selectField({
+        label: "Badge Type"|t('sprout-forms-google-recaptcha'),
+        instructions: 'Select the type of badge for this invisible captcha.'|t('sprout-forms-google-recaptcha'),
+        id: 'googleRecaptchaBadge',
+        name: 'captchaSettings['~captchaId~'][googleRecaptchaBadge]',
+        value: settings['googleRecaptchaBadge'] ?? 'bottomright',
+        options: [{
+            value: 'bottomright',
+            label: 'Bottom-right',
+        }, {
+            value: 'bottomleft',
+            label: 'Bottom-left',
+        }, {
+            value: 'inline',
+            label: 'Inline',
+        }]
+    }) }}
+</div>

--- a/src/templates/_integrations/sproutforms/captchas/GoogleRecaptcha/settings.twig
+++ b/src/templates/_integrations/sproutforms/captchas/GoogleRecaptcha/settings.twig
@@ -62,3 +62,13 @@
         }]
     }) }}
 </div>
+
+{{ forms.lightswitchField({
+    label: "Include API Code"|t('sprout-base-email'),
+    instructions: "Whether to automatically include the API code. Useful for performance optimisation."|t('sprout-base-email'),
+    id: 'googleRecaptchaIncludeApi',
+    name: 'captchaSettings['~captchaId~'][googleRecaptchaIncludeApi]',
+    on: settings['googleRecaptchaIncludeApi'] ?? true,
+    onLabel: "Enable"|t('sprout-base-email'),
+    offLabel: "Disable"|t('sprout-base-email')
+}) }}


### PR DESCRIPTION
This adds a dropdown to settings to select between the v2 checkbox and v2 invisible captcha. In addition, this also adds a badge dropdown when selecting the invisible captcha, so you can customise placement on the captcha, as per https://developers.google.com/recaptcha/docs/invisible#config

Doing all safety checks for backwards compatibility, and will render the checkbox by default.