### PR TITLE
Environment Variables

### DIFF
--- a/src/integrations/sproutforms/captchas/GoogleRecaptcha.php
+++ b/src/integrations/sproutforms/captchas/GoogleRecaptcha.php
@@ -116,8 +116,8 @@ class GoogleRecaptcha extends Captcha
     public function __construct()
     {
         $settings = $this->getSettings();
-        $this->siteKey = $settings['googleRecaptchaSiteKey'] ?? null;
-        $this->secretKey = $settings['googleRecaptchaSecretKey'] ?? null;
+        $this->siteKey = Craft::parseEnv($settings['googleRecaptchaSiteKey']) ?? null;
+        $this->secretKey = Craft::parseEnv($settings['googleRecaptchaSecretKey']) ?? null;
         $this->remoteIp = $_SERVER['REMOTE_ADDR'];
     }
 

--- a/src/templates/_integrations/sproutforms/captchas/GoogleRecaptcha/settings.twig
+++ b/src/templates/_integrations/sproutforms/captchas/GoogleRecaptcha/settings.twig
@@ -1,24 +1,26 @@
 {% import "_includes/forms" as forms %}
 
-{{ forms.textField({
+{{ forms.autosuggestField({
     label: 'Site Key'|t('sprout-forms-google-recaptcha'),
     instructions: 'Manage your Google reCAPTCHA <a href="{url}">API key settings</a>.'|t('sprout-forms-google-recaptcha', {
         url: 'https://www.google.com/recaptcha/admin'
     }),
     id: 'googleRecaptchaSiteKey',
     name: 'captchaSettings['~captchaId~'][googleRecaptchaSiteKey]',
+    suggestEnvVars: true,
     required: true,
     errors: null,
     value: settings['googleRecaptchaSiteKey'] ?? null
 }) }}
 
-{{ forms.textField({
+{{ forms.autosuggestField({
     label: 'Secret key'|t('sprout-forms-google-recaptcha'),
     instructions: 'Manage your Google reCAPTCHA <a href="{url}">API key settings</a>.'|t('sprout-forms-google-recaptcha', {
         url: 'https://www.google.com/recaptcha/admin'
     }),
     id: 'googleRecaptchaSecretKey',
     name: 'captchaSettings['~captchaId~'][googleRecaptchaSecretKey]',
+    suggestEnvVars: true,
     required: true,
     value: settings['googleRecaptchaSecretKey'] ?? null
 }) }}


### PR DESCRIPTION
When using Craft's project config, the `siteKey` and `secretKey` get added to the `project.yaml`. This PR enables Craft's environment variables so sensitive data doesn't get committed to the repo.