### PR TITLE
Bugfix: Add Schema Version Check Before Running Migrations

### DIFF
--- a/src/migrations/m191119_000000_set_default_recaptcha_css.php
+++ b/src/migrations/m191119_000000_set_default_recaptcha_css.php
@@ -27,6 +27,12 @@ class m191119_000000_set_default_recaptcha_css extends Migration
      */
     public function safeUp()
     {
+        $schemaVersion = Craft::$app->projectConfig->get('plugins.sprout-forms-google-recaptcha.schemaVersion', true);
+        // If the schemaVersion is already past 1.1.0, do not update project config
+        if (version_compare($schemaVersion, '1.1.0', '>=')) {
+          return true;
+        }
+
         $projectConfig = Craft::$app->getProjectConfig();
         $pluginHandle = 'sprout-forms';
         $currentSettings = $projectConfig->get(Plugins::CONFIG_PLUGINS_KEY.'.'.$pluginHandle.'.settings');

--- a/src/migrations/m200117_000000_update_settings.php
+++ b/src/migrations/m200117_000000_update_settings.php
@@ -21,6 +21,13 @@ class m200117_000000_update_settings extends Migration
      */
     public function safeUp()
     {
+
+        $schemaVersion = Craft::$app->projectConfig->get('plugins.sprout-forms-google-recaptcha.schemaVersion', true);
+        // If the schemaVersion is already past 1.1.0, do not update project config
+        if (version_compare($schemaVersion, '1.1.0', '>=')) {
+          return true;
+        }
+
         $projectConfig = Craft::$app->getProjectConfig();
         $pluginHandle = 'sprout-forms';
         $currentSettings = $projectConfig->get(Plugins::CONFIG_PLUGINS_KEY.'.'.$pluginHandle.'.settings');


### PR DESCRIPTION
Ran into some issues deploying because we have `allowAdminChanges` set to false. Updated the migrations according to this: https://putyourlightson.com/articles/a-technical-rundown-of-how-project-config-works#plugin-migrations so migrations are not run if the project config updates are already present